### PR TITLE
Update year length to the actual Gregorian length

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ const MINUTE = SECOND * SECONDS_PER_MINUTE;
 const HOUR = MINUTE * MINUTES_PER_HOUR;
 const DAY = HOUR * HOURS_PER_DAY;
 const WEEK = DAY * DAYS_PER_WEEK;
-const YEAR = DAY * 365.24;
+const YEAR = DAY * 365.2425;
 const NORMAL_YEAR = DAY * 365;
 const LEAP_YEAR = DAY * 366;
 const DECADE = 10 * YEAR;
-const HALF_YEAR = YEAR/2;
-const AVERAGE_MONTH = YEAR/12;
+const HALF_YEAR = YEAR / 2;
+const AVERAGE_MONTH = YEAR / MONTHS_PER_YEAR;
 
 module.exports = {
         SECOND: SECOND

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-constants",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Some constants for convenient amounts of time, all in ms",
   "main": "timeConstants.js",
   "scripts": {

--- a/timeConstants.js
+++ b/timeConstants.js
@@ -12,12 +12,12 @@ const MINUTE = SECOND * SECONDS_PER_MINUTE;
 const HOUR = MINUTE * MINUTES_PER_HOUR;
 const DAY = HOUR * HOURS_PER_DAY;
 const WEEK = DAY * DAYS_PER_WEEK;
-const YEAR = DAY * 365.24;
+const YEAR = DAY * 365.2425;
 const NORMAL_YEAR = DAY * 365;
 const LEAP_YEAR = DAY * 366;
 const DECADE = 10 * YEAR;
-const HALF_YEAR = YEAR/2;
-const AVERAGE_MONTH = YEAR/12;
+const HALF_YEAR = YEAR / 2;
+const AVERAGE_MONTH = YEAR / MONTHS_PER_YEAR;
 
 module.exports = {
         SECOND: SECOND


### PR DESCRIPTION
The Gregorian Calendar, the one we generally use for day to day, has an average year length of 365.2425 days. This is because the three rules for counting leap years are:

- year % 4 == 0: leap
- year % 100 == 0: normal
- year % 400 == 0: leap

Which is why 2000, for example, was a leap year. So it would be a good idea to update this number to be more accurate.

On a side note, the value before this commit, 365.24, _is_ accurate for the Julian Calendar, on which the Gregorian is based. It just started getting out of sync with the seasons (Easter was creeping closer to June), so a revision was commissioned, and now here we are!